### PR TITLE
[nightshift] dead-code: Remove duplicated SQLite utility functions

### DIFF
--- a/packages/cli/src/lib/cursor.ts
+++ b/packages/cli/src/lib/cursor.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
-import { copyFile, mkdtemp, rm } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
+import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import Database from "better-sqlite3";
 import type { UsageSummary } from "../interfaces";
@@ -14,6 +13,7 @@ import {
   getRecentWindowStart,
   normalizeModelName,
 } from "./utils";
+import { isSqliteLockedError, withSqliteSnapshot } from "./sqlite";
 
 const CURSOR_CONFIG_DIR_ENV = "CURSOR_CONFIG_DIR";
 const CURSOR_STATE_DB_PATH_ENV = "CURSOR_STATE_DB_PATH";
@@ -159,36 +159,6 @@ function readCursorAuthStateFromDatabase(databasePath: string) {
   }
 }
 
-function isSqliteLockedError(error: unknown) {
-  return error instanceof Error && /database is locked/i.test(error.message);
-}
-
-async function withCursorStateSnapshot<T>(
-  databasePath: string,
-  callback: (snapshotPath: string) => Promise<T>,
-) {
-  const snapshotDir = await mkdtemp(join(tmpdir(), "slopmeter-cursor-"));
-  const snapshotPath = join(snapshotDir, "state.vscdb");
-
-  await copyFile(databasePath, snapshotPath);
-
-  for (const suffix of ["-shm", "-wal"]) {
-    const companionPath = `${databasePath}${suffix}`;
-
-    if (!existsSync(companionPath)) {
-      continue;
-    }
-
-    await copyFile(companionPath, `${snapshotPath}${suffix}`);
-  }
-
-  try {
-    return await callback(snapshotPath);
-  } finally {
-    await rm(snapshotDir, { recursive: true, force: true });
-  }
-}
-
 async function readCursorAuthState(databasePath: string) {
   try {
     return readCursorAuthStateFromDatabase(databasePath);
@@ -197,7 +167,7 @@ async function readCursorAuthState(databasePath: string) {
       throw error;
     }
 
-    return withCursorStateSnapshot(databasePath, async (snapshotPath) =>
+    return withSqliteSnapshot(databasePath, "cursor", async (snapshotPath) =>
       readCursorAuthStateFromDatabase(snapshotPath),
     );
   }

--- a/packages/cli/src/lib/open-code.ts
+++ b/packages/cli/src/lib/open-code.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
-import { copyFile, mkdtemp, rm } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
+import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import type { UsageSummary } from "../interfaces";
 import {
@@ -16,6 +15,7 @@ import {
   parseJsonTextWithLimit,
   readJsonDocument,
 } from "./utils";
+import { isSqliteLockedError, withSqliteSnapshot } from "./sqlite";
 
 interface OpenCodeTokenCache {
   read?: number;
@@ -147,36 +147,6 @@ function parseOpenCodeMessageData(
   };
 }
 
-function isSqliteLockedError(error: unknown) {
-  return error instanceof Error && /database is locked/i.test(error.message);
-}
-
-async function withDatabaseSnapshot<T>(
-  databasePath: string,
-  callback: (snapshotPath: string) => Promise<T>,
-) {
-  const snapshotDir = await mkdtemp(join(tmpdir(), "slopmeter-opencode-"));
-  const snapshotPath = join(snapshotDir, "opencode.db");
-
-  await copyFile(databasePath, snapshotPath);
-
-  for (const suffix of ["-shm", "-wal"]) {
-    const companionPath = `${databasePath}${suffix}`;
-
-    if (!existsSync(companionPath)) {
-      continue;
-    }
-
-    await copyFile(companionPath, `${snapshotPath}${suffix}`);
-  }
-
-  try {
-    return await callback(snapshotPath);
-  } finally {
-    await rm(snapshotDir, { recursive: true, force: true });
-  }
-}
-
 async function iterateOpenCodeDatabaseMessages(
   databasePath: string,
   onMessage: (message: OpenCodeMessage) => void,
@@ -216,7 +186,7 @@ async function loadOpenCodeDatabaseMessages(
       throw error;
     }
 
-    await withDatabaseSnapshot(databasePath, async (snapshotPath) => {
+    await withSqliteSnapshot(databasePath, "opencode", async (snapshotPath) => {
       await iterateOpenCodeDatabaseMessages(snapshotPath, onMessage);
     });
   }


### PR DESCRIPTION
Automated by **Nightshift v3** (GLM 5.1).

**Task:** dead-code
**Category:** pr
**Repo:** micr-dev/tokens

## Changes

Removed duplicated SQLite utility functions from `cursor.ts` and `open-code.ts` that already exist as shared exports in `sqlite.ts`.

### Details
- Removed local `isSqliteLockedError()` from `cursor.ts` (line 162) and `open-code.ts` (line 150) — identical to exported version in `sqlite.ts`
- Removed local `withCursorStateSnapshot()` from `cursor.ts` (lines 166-190) — replaced with `withSqliteSnapshot(databasePath, "cursor", callback)`
- Removed local `withDatabaseSnapshot()` from `open-code.ts` (lines 154-178) — replaced with `withSqliteSnapshot(databasePath, "opencode", callback)`
- Cleaned up unused imports (`copyFile`, `mkdtemp`, `rm`, `tmpdir`)

**Net:** 66 lines removed, 6 added. Behavior unchanged.

Merge if useful, close if not.