### PR TITLE
[nightshift] lint-fix: merge duplicate imports from ../lib/usage

### DIFF
--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,7 +1,6 @@
 import { buildAnalytics } from "../lib/analytics";
-import { getPublishedSvgMarkup } from "../lib/usage";
+import { getPublishedSvgMarkup, getPublishedUsagePayload } from "../lib/usage";
 import { SvgUsage } from "./svg-usage";
-import { getPublishedUsagePayload } from "../lib/usage";
 
 export default async function Page() {
   const [svgMarkup, publishedUsage] = await Promise.all([


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** lint-fix
**Category:** pr
**Cost Tier:** low

## Changes

Merged duplicate imports from `../lib/usage` in `packages/web/app/page.tsx`:
- Combined `getPublishedSvgMarkup` and `getPublishedUsagePayload` into a single import statement
- Removed redundant second import from the same module

The codebase is very clean — this was the only lint-level issue found across all TypeScript files. No unused imports, no console.log statements in non-test files, no explicit `any` types, no empty catch blocks.

Merge if useful, close if not.