### PR TITLE
fix(publish): prevent refolding agy+gemini on every publish cycle

### DIFF
--- a/packages/web/scripts/publish-usage.ts
+++ b/packages/web/scripts/publish-usage.ts
@@ -1093,16 +1093,17 @@ function foldGeminiIntoAntigravityProvider(
   providers: PublishedUsagePayload["providers"],
   endDate: Date,
 ) {
-  const continuitySources = providers.filter(
+  const agySources = providers.filter(
     (provider) => provider.provider === "agy" || provider.provider === "gemini",
   );
 
-  if (continuitySources.length === 0) {
+  if (agySources.length <= 1) {
+    // Already folded (single "agy", no raw "gemini") or nothing to fold.
     return providers;
   }
 
   const antigravitySummary = toJsonUsageSummary(
-    mergeUsageSummaries("agy", continuitySources.map(toUsageSummary), endDate),
+    mergeUsageSummaries("agy", agySources.map(toUsageSummary), endDate),
   );
 
   return [


### PR DESCRIPTION
## Problem

March 17 agy data shows 3.39B tokens on tokens.micr.dev — 15x inflated from the true ~226M. History snapshots reveal the number growing by ~226M per `publish:web` run.

## Root Cause

`foldGeminiIntoAntigravityProvider` merges `agy` + `gemini` providers into a single `agy` provider inside `sanitizePublishedPayload`. This runs on every publish cycle. The hosted/published payload (already folded) is treated as raw input and folded again, stacking duplicate data.

## Fix

Changed the guard from `length === 0` to `length <= 1`. When only a single `agy` provider exists (already folded, no raw `gemini`), the merge is skipped. Folding only triggers when both `agy` and `gemini` raw providers are present.

## Evidence

History snapshots show March 17 agy total progression:
- 06-13 01:45: 226M (original `gemini` reading)
- 06-13 13:56: 1.81B
- 06-19 22:45: 2.71B
- Published now: 3.39B

Each publish added another ~226M.

## Follow-up

The published payload needs to be corrected after merge (true March 17 agy should be ~226M).